### PR TITLE
Manual-entry-number-pad

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,40 @@
       <button class="menu-button" id="restart-appliance-btn">Restart Appliance</button>
     </div>
   </div>
+
+  <!-- Manual Entry Modal -->
+  <div class="manual-entry-modal" id="manual-entry-modal">
+    <div class="manual-entry-content">
+      <h2>Manual Entry</h2>
+      <div class="input-section">
+        <label for="manual-onecard">OneCard Number:</label>
+        <input type="text" id="manual-onecard" placeholder="Enter OneCard number" maxlength="20" readonly>
+      </div>
+      <div class="numberpad">
+        <div class="numberpad-row">
+          <button class="num-btn" data-number="1">1</button>
+          <button class="num-btn" data-number="2">2</button>
+          <button class="num-btn" data-number="3">3</button>
+        </div>
+        <div class="numberpad-row">
+          <button class="num-btn" data-number="4">4</button>
+          <button class="num-btn" data-number="5">5</button>
+          <button class="num-btn" data-number="6">6</button>
+        </div>
+        <div class="numberpad-row">
+          <button class="num-btn" data-number="7">7</button>
+          <button class="num-btn" data-number="8">8</button>
+          <button class="num-btn" data-number="9">9</button>
+        </div>
+        <div class="numberpad-row">
+          <button class="num-btn" data-number="0">0</button>
+          <button class="num-btn clear-btn" id="clear-btn">Clear</button>
+          <button class="num-btn submit-btn" id="submit-manual-btn">Submit</button>
+        </div>
+      </div>
+      <button class="close-btn" id="close-manual-btn">Close</button>
+    </div>
+  </div>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="msapplication-config" content="none">
   <link rel="stylesheet" type="text/css" href="/src/styles.css">
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=close" />
   <script type="module" src="/src/main.ts" defer></script>
 </head>
 
@@ -39,10 +41,15 @@
   <!-- Manual Entry Modal -->
   <div class="manual-entry-modal" id="manual-entry-modal">
     <div class="manual-entry-content">
-      <h2>Manual Entry</h2>
+      <div class="modal-header">
+        <h2>Manual Entry</h2>
+        <button class="close-x-btn" id="close-manual-btn"><span class="material-symbols-outlined">
+            close
+          </span></button>
+      </div>
       <div class="input-section">
         <label for="manual-onecard">OneCard Number:</label>
-        <input type="text" id="manual-onecard" placeholder="Enter OneCard number" maxlength="20" readonly>
+        <input type="text" id="manual-onecard" placeholder="Enter OneCard number" maxlength="7" readonly>
       </div>
       <div class="numberpad">
         <div class="numberpad-row">
@@ -62,11 +69,12 @@
         </div>
         <div class="numberpad-row">
           <button class="num-btn" data-number="0">0</button>
-          <button class="num-btn clear-btn" id="clear-btn">Clear</button>
-          <button class="num-btn submit-btn" id="submit-manual-btn">Submit</button>
+        </div>
+        <div class="action-buttons">
+          <button class="action-btn clear-btn" id="clear-btn">Clear</button>
+          <button class="action-btn submit-btn" id="submit-manual-btn">Submit</button>
         </div>
       </div>
-      <button class="close-btn" id="close-manual-btn">Close</button>
     </div>
   </div>
 </body>

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,6 +74,19 @@ async fn submit_barcode_entry(
         .unwrap();
     Ok(())
 }
+
+#[tauri::command]
+async fn submit_manual_entry(
+    config_manager: tauri::State<'_, ConfigManager>,
+    onecard: String,
+) -> Result<(), String> {
+    let name = "Manual Entry".to_string();
+    submit_entry(config_manager, CardData { name, onecard })
+        .await
+        .unwrap();
+    Ok(())
+}
+
 #[tauri::command]
 async fn first_run_trigger(app: tauri::AppHandle) {
     let main_window = app.get_webview_window("main").unwrap();
@@ -141,6 +154,7 @@ fn main() {
             send_heartbeat_command,
             submit_swipe_entry,
             submit_barcode_entry,
+            submit_manual_entry,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Tauri application");

--- a/src/hid/barcodeScanner.ts
+++ b/src/hid/barcodeScanner.ts
@@ -1,10 +1,13 @@
+import { soundManager } from '../sound/soundManager';
+
 const entryDataEl = document.getElementById('entry-data');
 
-
 export const updateScanData = (payload: string) => {
-    if (entryDataEl) {
-      const body = document.body;
-      body.style.backgroundColor = "green";
-      entryDataEl.innerHTML = `<div class="entry-data-container"><p>Onecard: ${payload}</p></div>`;
-    }
-  };
+  if (entryDataEl) {
+    const body = document.body;
+    body.style.backgroundColor = "green";
+    entryDataEl.innerHTML = `<div class="entry-data-container"><p>Onecard: ${payload}</p></div>`;
+    // Play a beep sound for successful scan detection
+    soundManager.playBeep(800, 150);
+  }
+};

--- a/src/hid/magstripReader.ts
+++ b/src/hid/magstripReader.ts
@@ -1,3 +1,5 @@
+import { soundManager } from '../sound/soundManager';
+
 const entryDataEl = document.getElementById('entry-data');
 
 export interface swipeData {
@@ -10,5 +12,7 @@ export const updateSwipeData = (payload: swipeData) => {
     const body = document.body;
     body.style.backgroundColor = "green";
     entryDataEl.innerHTML = `<div><p>Name: ${payload.name}</p><p>Onecard: ${payload.onecard}</p></div>`;
+    // Play a beep sound for successful swipe detection
+    soundManager.playBeep(800, 150);
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -145,7 +145,7 @@ function initializeManualEntry() {
   numBtns.forEach(btn => {
     btn.addEventListener('click', () => {
       const number = (btn as HTMLElement).getAttribute('data-number');
-      if (number && currentOneCardInput.length < 20) {
+      if (number && currentOneCardInput.length < 7) {
         currentOneCardInput += number;
         oneCardInput.value = currentOneCardInput;
         soundManager.playNumberBeep();

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,6 @@ function initializeMenu() {
   manualEntryBtn?.addEventListener('click', () => {
     console.log('Manual Entry clicked');
     soundManager.playBeep(700, 120);
-    // TODO: Implement manual entry functionality
     closeMenu();
   });
 
@@ -212,9 +211,12 @@ function showEntrySuccess() {
   const entryData = document.getElementById('entry-data');
   if (entryData) {
     entryData.innerHTML = '<p>Entry submitted successfully!</p>';
+    // Change screen color to green for success
+    document.body.style.backgroundColor = 'green';
     // Reset after 3 seconds
     setTimeout(() => {
       entryData.innerHTML = '<p>Swipe your card or scan your barcode to record an entry...</p>';
+      document.body.style.backgroundColor = '#00447c';
     }, 3000);
   }
 }
@@ -224,9 +226,12 @@ function showEntryError() {
   const entryData = document.getElementById('entry-data');
   if (entryData) {
     entryData.innerHTML = '<p>Error submitting entry. Please try again.</p>';
+    // Change screen color to red for error
+    document.body.style.backgroundColor = '#cc0000';
     // Reset after 3 seconds
     setTimeout(() => {
       entryData.innerHTML = '<p>Swipe your card or scan your barcode to record an entry...</p>';
+      document.body.style.backgroundColor = '#00447c';
     }, 3000);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { startHIDManager } from './hid/HIDManager';
+import { soundManager } from './sound/soundManager';
 
 interface config {
   server_url: string;
@@ -13,6 +14,10 @@ interface config {
 // Menu state management
 let menuPressTimer: NodeJS.Timeout | null = null;
 let isMenuOpen = false;
+
+// Manual entry state management
+let isManualEntryOpen = false;
+let currentOneCardInput = '';
 
 // Menu functionality
 function initializeMenu() {
@@ -70,18 +75,21 @@ function initializeMenu() {
   // Button handlers
   manualEntryBtn?.addEventListener('click', () => {
     console.log('Manual Entry clicked');
+    soundManager.playBeep(700, 120);
     // TODO: Implement manual entry functionality
     closeMenu();
   });
 
   showConfigBtn?.addEventListener('click', () => {
     console.log('Show Config clicked');
+    soundManager.playBeep(700, 120);
     // TODO: Implement config display functionality
     closeMenu();
   });
 
   restartApplianceBtn?.addEventListener('click', () => {
     console.log('Restart Appliance clicked');
+    soundManager.playBeep(700, 120);
     // TODO: Implement restart functionality
     closeMenu();
   });
@@ -100,6 +108,126 @@ function closeMenu() {
   if (menuModal && isMenuOpen) {
     isMenuOpen = false;
     menuModal.classList.remove('active');
+  }
+}
+
+// Manual entry functionality
+function initializeManualEntry() {
+  const manualEntryBtn = document.getElementById('manual-entry-btn');
+  const manualEntryModal = document.getElementById('manual-entry-modal');
+  const closeManualBtn = document.getElementById('close-manual-btn');
+  const numBtns = document.querySelectorAll('.num-btn[data-number]');
+  const clearBtn = document.getElementById('clear-btn');
+  const submitManualBtn = document.getElementById('submit-manual-btn');
+  const oneCardInput = document.getElementById('manual-onecard') as HTMLInputElement;
+
+  if (!manualEntryBtn || !manualEntryModal || !closeManualBtn) return;
+
+  // Open manual entry modal
+  manualEntryBtn.addEventListener('click', () => {
+    openManualEntry();
+    closeMenu();
+  });
+
+  // Close manual entry modal
+  closeManualBtn.addEventListener('click', () => {
+    closeManualEntry();
+  });
+
+  // Close when clicking outside
+  manualEntryModal.addEventListener('click', (e) => {
+    if (e.target === manualEntryModal) {
+      closeManualEntry();
+    }
+  });
+
+  // Number button functionality
+  numBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const number = (btn as HTMLElement).getAttribute('data-number');
+      if (number && currentOneCardInput.length < 20) {
+        currentOneCardInput += number;
+        oneCardInput.value = currentOneCardInput;
+        soundManager.playNumberBeep();
+      }
+    });
+  });
+
+  // Clear button functionality
+  clearBtn?.addEventListener('click', () => {
+    currentOneCardInput = '';
+    oneCardInput.value = '';
+    soundManager.playBeep(500, 100);
+  });
+
+  // Submit button functionality
+  submitManualBtn?.addEventListener('click', async () => {
+    if (currentOneCardInput.trim()) {
+      try {
+        await invoke('submit_manual_entry', { onecard: currentOneCardInput });
+        // Show success message
+        soundManager.playSuccess();
+        showEntrySuccess();
+        closeManualEntry();
+      } catch (error) {
+        console.error('Manual entry submission failed:', error);
+        // Show error message
+        soundManager.playError();
+        showEntryError();
+      }
+    }
+  });
+}
+
+function openManualEntry() {
+  const manualEntryModal = document.getElementById('manual-entry-modal');
+  if (manualEntryModal && !isManualEntryOpen) {
+    isManualEntryOpen = true;
+    manualEntryModal.classList.add('active');
+    // Reset input
+    currentOneCardInput = '';
+    const oneCardInput = document.getElementById('manual-onecard') as HTMLInputElement;
+    if (oneCardInput) {
+      oneCardInput.value = '';
+    }
+  }
+}
+
+function closeManualEntry() {
+  const manualEntryModal = document.getElementById('manual-entry-modal');
+  if (manualEntryModal && isManualEntryOpen) {
+    isManualEntryOpen = false;
+    manualEntryModal.classList.remove('active');
+    // Reset input
+    currentOneCardInput = '';
+    const oneCardInput = document.getElementById('manual-onecard') as HTMLInputElement;
+    if (oneCardInput) {
+      oneCardInput.value = '';
+    }
+  }
+}
+
+function showEntrySuccess() {
+  // Update the main display to show success
+  const entryData = document.getElementById('entry-data');
+  if (entryData) {
+    entryData.innerHTML = '<p>Entry submitted successfully!</p>';
+    // Reset after 3 seconds
+    setTimeout(() => {
+      entryData.innerHTML = '<p>Swipe your card or scan your barcode to record an entry...</p>';
+    }, 3000);
+  }
+}
+
+function showEntryError() {
+  // Update the main display to show error
+  const entryData = document.getElementById('entry-data');
+  if (entryData) {
+    entryData.innerHTML = '<p>Error submitting entry. Please try again.</p>';
+    // Reset after 3 seconds
+    setTimeout(() => {
+      entryData.innerHTML = '<p>Swipe your card or scan your barcode to record an entry...</p>';
+    }, 3000);
   }
 }
 
@@ -130,6 +258,7 @@ async function scheduleHeartbeat() {
 
   // Initialize menu functionality
   initializeMenu();
+  initializeManualEntry(); // Initialize manual entry functionality
 
   // Heartbeat cron task: every 10 +/- 5 minutes
   scheduleHeartbeat();

--- a/src/sound/soundManager.ts
+++ b/src/sound/soundManager.ts
@@ -1,0 +1,66 @@
+// Sound Manager for Guestbook Application
+export class SoundManager {
+  private audioContext: AudioContext | null = null;
+  private gainNode: GainNode | null = null;
+
+  constructor() {
+    this.initAudio();
+  }
+
+  private initAudio() {
+    try {
+      this.audioContext = new (window.AudioContext ||
+        (window as any).webkitAudioContext)();
+      this.gainNode = this.audioContext.createGain();
+      this.gainNode.connect(this.audioContext.destination);
+      this.gainNode.gain.value = 0.3; // Set volume to 30%
+    } catch (error) {
+      console.warn('Audio context not supported, sounds will be disabled');
+    }
+  }
+
+  // Play a beep sound for numberpad buttons
+  playBeep(frequency: number = 800, duration: number = 100) {
+    if (!this.audioContext || !this.gainNode) return;
+
+    try {
+      const oscillator = this.audioContext.createOscillator();
+      const gainNode = this.audioContext.createGain();
+
+      oscillator.connect(gainNode);
+      gainNode.connect(this.gainNode);
+
+      oscillator.frequency.value = frequency;
+      oscillator.type = 'sine';
+
+      gainNode.gain.setValueAtTime(0.1, this.audioContext.currentTime);
+      gainNode.gain.exponentialRampToValueAtTime(
+        0.01,
+        this.audioContext.currentTime + duration / 1000
+      );
+
+      oscillator.start(this.audioContext.currentTime);
+      oscillator.stop(this.audioContext.currentTime + duration / 1000);
+    } catch (error) {
+      console.warn('Failed to play beep sound:', error);
+    }
+  }
+
+  // Play success sound
+  playSuccess() {
+    this.playBeep(1000, 200);
+  }
+
+  // Play error sound
+  playError() {
+    this.playBeep(400, 300);
+  }
+
+  // Play number button sound
+  playNumberBeep() {
+    this.playBeep(600, 80);
+  }
+}
+
+// Create and export a singleton instance
+export const soundManager = new SoundManager();

--- a/src/sound/soundManager.ts
+++ b/src/sound/soundManager.ts
@@ -14,7 +14,7 @@ export class SoundManager {
       this.gainNode = this.audioContext.createGain();
       this.gainNode.connect(this.audioContext.destination);
       this.gainNode.gain.value = 0.3; // Set volume to 30%
-    } catch (error) {
+    } catch (_error) {
       console.warn('Audio context not supported, sounds will be disabled');
     }
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -261,6 +261,47 @@ h1 {
   color: white;
 }
 
+.modal-header {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.modal-header h2 {
+  margin: 0;
+}
+
+.close-x-btn {
+  position: absolute;
+  right: -20px;
+  top: -20px;
+  width: 40px;
+  height: 40px;
+  background-color: #cc0000;
+  color: white;
+  border: 2px solid white;
+  border-radius: 50%;
+  font-size: 20px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.close-x-btn:hover {
+  background-color: #ff0000;
+  transform: scale(1.1);
+}
+
+.close-x-btn:active {
+  transform: scale(0.95);
+}
+
 .input-section {
   display: flex;
   flex-direction: column;
@@ -301,6 +342,17 @@ h1 {
   justify-content: center;
 }
 
+.numberpad-row:last-of-type {
+  justify-content: center;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 10px;
+}
+
 .num-btn {
   width: 80px;
   height: 80px;
@@ -313,6 +365,9 @@ h1 {
   font-family: 'Poppins', sans-serif;
   cursor: pointer;
   transition: background-color 0.2s ease, transform 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .num-btn:hover {
@@ -321,6 +376,34 @@ h1 {
 }
 
 .num-btn:active {
+  transform: translateY(0);
+  background-color: #0055aa;
+}
+
+.action-btn {
+  background-color: #0066cc;
+  color: white;
+  border: 2px solid white;
+  border-radius: 10px;
+  padding: 15px 30px;
+  font-size: clamp(20px, 2.5vw, 24px);
+  font-weight: 600;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+  min-width: 120px;
+}
+
+.action-btn:hover {
+  background-color: #0088ff;
+  transform: translateY(-2px);
+}
+
+.action-btn:active {
   transform: translateY(0);
   background-color: #0055aa;
 }
@@ -381,5 +464,20 @@ h1 {
 
   .numberpad-row {
     gap: 8px;
+  }
+
+  .action-btn {
+    padding: 12px 25px;
+    min-height: 50px;
+    min-width: 100px;
+    font-size: clamp(18px, 2.2vw, 22px);
+  }
+
+  .close-x-btn {
+    width: 35px;
+    height: 35px;
+    font-size: 18px;
+    right: -15px;
+    top: -15px;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -212,3 +212,174 @@ h1 {
     min-height: 50px;
   }
 }
+
+/* Manual Entry Modal Styles */
+.manual-entry-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.manual-entry-modal.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.manual-entry-content {
+  background-color: #00447c;
+  border: 3px solid white;
+  border-radius: 15px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 400px;
+  max-width: 500px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  transform: scale(0.8);
+  transition: transform 0.3s ease;
+}
+
+.manual-entry-modal.active .manual-entry-content {
+  transform: scale(1);
+}
+
+.manual-entry-content h2 {
+  text-align: center;
+  margin: 0 0 20px 0;
+  font-size: clamp(32px, 4vw, 48px);
+  color: white;
+}
+
+.input-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.input-section label {
+  font-size: clamp(20px, 2.5vw, 24px);
+  font-weight: 600;
+  color: white;
+}
+
+.input-section input {
+  padding: 15px;
+  font-size: clamp(24px, 3vw, 28px);
+  border: 2px solid white;
+  border-radius: 10px;
+  background-color: #0066cc;
+  color: white;
+  text-align: center;
+  font-family: 'Poppins', sans-serif;
+}
+
+.input-section input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.numberpad {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 20px 0;
+}
+
+.numberpad-row {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.num-btn {
+  width: 80px;
+  height: 80px;
+  background-color: #0066cc;
+  color: white;
+  border: 2px solid white;
+  border-radius: 10px;
+  font-size: clamp(24px, 3vw, 28px);
+  font-weight: 600;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.num-btn:hover {
+  background-color: #0088ff;
+  transform: translateY(-2px);
+}
+
+.num-btn:active {
+  transform: translateY(0);
+  background-color: #0055aa;
+}
+
+.clear-btn {
+  background-color: #cc6600;
+}
+
+.clear-btn:hover {
+  background-color: #ff8800;
+}
+
+.submit-btn {
+  background-color: #00cc66;
+}
+
+.submit-btn:hover {
+  background-color: #00ff88;
+}
+
+.close-btn {
+  background-color: #cc0000;
+  color: white;
+  border: 2px solid white;
+  border-radius: 10px;
+  padding: 15px 30px;
+  font-size: clamp(20px, 2.5vw, 24px);
+  font-weight: 600;
+  font-family: 'Poppins', sans-serif;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  align-self: center;
+}
+
+.close-btn:hover {
+  background-color: #ff0000;
+  transform: translateY(-2px);
+}
+
+.close-btn:active {
+  transform: translateY(0);
+  background-color: #aa0000;
+}
+
+/* Responsive adjustments for manual entry */
+@media screen and (max-width: 1200px) {
+  .manual-entry-content {
+    padding: 30px;
+    min-width: 350px;
+    max-width: 450px;
+  }
+
+  .num-btn {
+    width: 70px;
+    height: 70px;
+    font-size: clamp(20px, 2.5vw, 24px);
+  }
+
+  .numberpad-row {
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
- Implemented sound feedback for successful scans and swipes in barcodeScanner.ts and magstripReader.ts using the soundManager.
- Updated background color changes in main.ts to visually indicate success (green) and error (red) states during entry submissions.
- Refactored entry data display logic in HIDManager.ts to improve user experience and maintain consistency in messaging.
- Added error sound feedback for device not found scenarios in HIDManager.ts.

## Summary by Sourcery

Add manual entry number pad UI and enhance user feedback with sounds and visual indicators across scanning, swiping, and manual submissions.

New Features:
- Introduce a manual entry modal with on-screen number pad for OneCard number input
- Add SoundManager to play beeps, success, and error sounds
- Expose a new Tauri command submit_manual_entry for manual submissions

Enhancements:
- Integrate sound feedback for successful barcode scans and card swipes
- Play error sounds on device not found and entry submission failures
- Visually indicate entry success (green) and errors (red) with background color updates
- Refactor entry data messaging in HIDManager for consistency using a default message